### PR TITLE
Ignore `__mdb_internal`-prefixed databases in `sync metadata` precheck.

### DIFF
--- a/src/main/java/com/mongodb/shardsync/ShardClient.java
+++ b/src/main/java/com/mongodb/shardsync/ShardClient.java
@@ -87,6 +87,7 @@ import com.mongodb.model.Shard;
 import com.mongodb.model.ShardTimestamp;
 import com.mongodb.model.StandardDatabaseCatalogProvider;
 import com.mongodb.model.User;
+import com.mongodb.util.DatabaseUtil;
 import com.mongodb.util.MaskUtil;
 import com.mongodb.util.bson.BsonUuidUtil;
 
@@ -919,7 +920,7 @@ public class ShardClient {
 		
 		for (Document db : databases) {
 			String dbName = db.getString("name");
-			if (!excludedSystemDbs.contains(dbName)) {
+			if (!DatabaseUtil.isSystemDatabase(dbName)) {
 				filteredDatabases.add(db);
 			}
 		}

--- a/src/main/java/com/mongodb/util/DatabaseUtil.java
+++ b/src/main/java/com/mongodb/util/DatabaseUtil.java
@@ -5,6 +5,8 @@ package com.mongodb.util;
  */
 public class DatabaseUtil {
 
+    private static final String MDB_INTERNAL_PREFIX = "__mdb_internal";
+
     /**
      * Checks if a database name is a MongoDB system database that should typically be excluded 
      * from user operations like syncing, dropping, or analysis.
@@ -16,10 +18,11 @@ public class DatabaseUtil {
         if (databaseName == null) {
             return false;
         }
-        
+
         return databaseName.equals("admin") || 
                databaseName.equals("config") || 
-               databaseName.equals("local");
+               databaseName.equals("local") ||
+               databaseName.startsWith(MDB_INTERNAL_PREFIX);
     }
     
     /**


### PR DESCRIPTION
…heck.